### PR TITLE
[#4] Testing treated path support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,8 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <querydsl.version>4.2.2</querydsl.version>
+        <querydsl.version>4.2.3-SNAPSHOT</querydsl.version>
+<!--        <querydsl.version>4.2.2</querydsl.version>-->
         <hibernate.version>5.4.10.Final</hibernate.version>
         <blaze-persistence.version>1.4.1</blaze-persistence.version>
     </properties>


### PR DESCRIPTION
Dependent on https://github.com/querydsl/querydsl/pull/2530

Tests will fail because `4.2.3-SNAPSHOT` is obviously unavailable.